### PR TITLE
Add sparql query for members of the House of Representatives of Nigeria

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -7,7 +7,9 @@ en = WikiData::Category.new('Category:Members of the House of Representatives (N
      WikiData::Category.new('Category:Women members of the House of Representatives (Nigeria)', 'en').member_titles |
      WikiData::Category.new('Category:People\'s Democratic Party members of the House of Representatives (Nigeria)', 'en').member_titles |
      WikiData::Category.new('Category:Members of the House of Representatives (Nigeria) from Rivers State', 'en').member_titles |
-     WikiData::Category.new('Category:Speakers of the House of Representatives (Nigeria)', 'en').member_titles 
+     WikiData::Category.new('Category:Speakers of the House of Representatives (Nigeria)', 'en').member_titles
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { en: en })
+sparq = 'SELECT ?item WHERE { ?item wdt:P39 wd:Q21290864 }'
+ids = EveryPolitician::Wikidata.sparql(sparq)
 
+EveryPolitician::Wikidata.scrape_wikidata(ids: ids, names: { en: en })

--- a/scraper.rb
+++ b/scraper.rb
@@ -9,7 +9,14 @@ en = WikiData::Category.new('Category:Members of the House of Representatives (N
      WikiData::Category.new('Category:Members of the House of Representatives (Nigeria) from Rivers State', 'en').member_titles |
      WikiData::Category.new('Category:Speakers of the House of Representatives (Nigeria)', 'en').member_titles
 
-sparq = 'SELECT ?item WHERE { ?item wdt:P39 wd:Q21290864 }'
+sparq = <<EOQ
+  SELECT ?item WHERE {
+    ?item p:P39 ?position_held .
+    ?position_held ps:P39 wd:Q21290864 ;
+                   pq:P2937 wd:Q20311259 .
+  }
+EOQ
+
 ids = EveryPolitician::Wikidata.sparql(sparq)
 
 EveryPolitician::Wikidata.scrape_wikidata(ids: ids, names: { en: en })


### PR DESCRIPTION
Part of: https://github.com/everypolitician/everypolitician-data/issues/27204

A member is no longer listed in any of the current categories being scraped as their membership has ceased. I have updated the member's wikidata item so that `position held` points to `Member of the House of Nigeria`. This PR adds a SPARQL query to fetch everyone with a P39 of Member of the House of Nigeria.